### PR TITLE
Add alternative promise implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The solutions are best read in the following order:
   - [__callbacks.js__](https://github.com/plaid/async-problem/blob/master/callbacks.js)
   - [__async.js__](https://github.com/plaid/async-problem/blob/master/async.js)
   - [__promises.js__](https://github.com/plaid/async-problem/blob/master/promises.js)
+  - [__promises-ramda.js__](https://github.com/plaid/async-problem/blob/master/promises-ramda.js)
   - [__coroutines-co.js__](https://github.com/plaid/async-problem/blob/master/coroutines-co.js)
   - [__coroutines-bluebird.js__](https://github.com/plaid/async-problem/blob/master/coroutines-bluebird.js)
   - [__await.js__](https://github.com/plaid/async-problem/blob/master/await.js)

--- a/promises-ramda.js
+++ b/promises-ramda.js
@@ -1,0 +1,41 @@
+/* jshint esnext:true */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const Promise = require('bluebird');
+const R = require('ramda');
+
+
+// join :: String -> String -> String
+const join = R.curryN(2, path.join);
+
+// readFile :: (Object, String) -> Promise String
+const readFile = R.curry(R.flip(Promise.promisify(fs.readFile)));
+
+// then :: (a -> b) -> Promise a -> Promise b
+const then = R.invoker(1, 'then');
+
+// concatFiles :: String -> Promise String
+const concatFiles = (dir) =>
+  R.pipe(
+    join(R.__, 'index.txt'),
+    readFile({encoding: 'utf8'}),
+    then(R.match(/^.*(?=\n)/gm)),
+    then(R.map(join(dir))),
+    then(R.map(readFile({encoding: 'utf8'}))),
+    then(Promise.all),
+    then(R.join(''))
+  )(dir);
+
+// write :: Object -> * -> *
+const write = R.flip(R.invoker(1, 'write'));
+
+
+const main = () => {
+  concatFiles(process.argv[2])
+  .then(write(process.stdout), write(process.stderr))
+};
+
+if (process.argv[1] === __filename) main();

--- a/test
+++ b/test
@@ -17,6 +17,7 @@ test synchronous.js
 test callbacks.js
 test async.js
 test promises.js
+test promises-ramda.js
 test coroutines-co.js
 test coroutines-bluebird.js
 test await.compiled.js


### PR DESCRIPTION
Hello @davidchambers 

Great job on this repository. It's a nice way to compare different asynchronous solutions.

But I still don't really understand the problem with promises? Sure, they have some unfortunate design choices that probably would have turned out better if the creators had realized that they where dealing with a monad.

But are they really that bad? Futures are #1 on the list and promises are #5. But as this PR shows we can implement something almost exactly like the future example with promises. This is standard promise stuff as found in ECMAScript 6. I'm only importing Bluebird to use it's neat `promisify` function.

What do you think? Am I missing something?