### PR TITLE
move to process.mainModule.filename to avoid extension issues

### DIFF
--- a/async.js
+++ b/async.js
@@ -32,4 +32,4 @@ const main = () => {
   });
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/await.js
+++ b/await.js
@@ -42,4 +42,4 @@ async function main() {
   process.stdout.write(results.join(''));
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/callbacks.js
+++ b/callbacks.js
@@ -33,4 +33,4 @@ const main = () => {
   });
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/coroutines-bluebird.js
+++ b/coroutines-bluebird.js
@@ -40,4 +40,4 @@ const main = () => {
         });
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/coroutines-co.js
+++ b/coroutines-co.js
@@ -45,4 +45,4 @@ const main = () => {
         });
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/kgo.js
+++ b/kgo.js
@@ -37,4 +37,4 @@ const main = () => {
   });
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/promises-ramda.js
+++ b/promises-ramda.js
@@ -42,4 +42,4 @@ const main = () => {
         });
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/promises.js
+++ b/promises.js
@@ -37,4 +37,4 @@ const main = () => {
         });
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/synchronous.js
+++ b/synchronous.js
@@ -26,4 +26,4 @@ const main = () => {
   process.stdout.write(S.lines(index).map(readFile).join(''));
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();

--- a/tasks.js
+++ b/tasks.js
@@ -48,4 +48,4 @@ const main = () => {
         });
 };
 
-if (process.argv[1] === __filename) main();
+if (process.mainModule.filename === __filename) main();


### PR DESCRIPTION
We currently use:

    if (process.argv[1] === __filename) main();

to determine if we are running as a module as opposed to running as a standalone script. This approach can be brittle, proven in cases where we attempt to run as a standalone script but omit the `.js` extension in the argument to `node`. In these cases, the conditional thinks we are running as a module and fails to call `main()`.

Using:

    if (process.mainModule.filename === __filename) main();

will avoid these issues.