### PR TITLE
bluebird-promisell version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The solutions are best read in the following order:
   - [__righto.js__](./righto.js)
   - [__promises.js__](./promises.js)
   - [__promises-ramda.js__](./promises-ramda.js)
+  - [__bluebird-promisell.js__](./bluebird-promisell.js)
   - [__most.js__](./most.js)
   - [__coroutines-co.js__](./coroutines-co.js)
   - [__coroutines-bluebird.js__](./coroutines-bluebird.js)

--- a/bluebird-promisell.js
+++ b/bluebird-promisell.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const Promise = require('bluebird');
+const P = require('bluebird-promisell');
+const R = require('ramda');
+const S = require('sanctuary');
+
+//    data Text = Buffer | String
+//    readFile :: String -> String -> Promise Error Text
+const readFile = R.curry((encoding, filename) =>
+  new Promise((resolve, reject) => {
+    fs.readFile(filename, {encoding: encoding}, (err, data) => {
+      if (err != null) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  })
+);
+
+//    readFileWithDirAndName :: String -> String -> String -> Promise Error String
+const readFileWithDirAndName = R.curry((encoding, dir, name) => {
+  const filePath = path.join(dir, name);
+  return readFile(encoding)(filePath);
+});
+
+//    readFilesWithDirAndNames :: String -> [String] -> Promise Error [String]
+const readFilesWithDirAndNames = R.compose(P.traversep, readFileWithDirAndName);
+
+//    concatFiles :: String -> Promise Error String
+const concatFiles = dir => {
+  const indexFileP = readFileWithDirAndName('utf8', dir, 'index.txt');
+  const fileNamesP = P.liftp1(S.lines)(indexFileP);
+  const readFilesWithNames = readFilesWithDirAndNames('utf8', dir);
+  const filesP = P.liftp1(readFilesWithNames)(fileNamesP);
+  return P.liftp1(R.join(''))(filesP);
+};
+
+
+const main = () => {
+  concatFiles(process.argv[2])
+  .then(data => {
+          process.stdout.write(data);
+          process.exit(0);
+        },
+        err => {
+          process.stderr.write(String(err) + '\n');
+          process.exit(1);
+        });
+};
+
+if (process.mainModule.filename === __filename) main();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "async": "1.2.x",
     "bluebird": "2.9.x",
+    "bluebird-promisell": "0.4.x",
     "co": "4.5.x",
     "data.task": "3.0.x",
     "foreign": "1.0.x",

--- a/test
+++ b/test
@@ -57,6 +57,7 @@ test kgo.js
 test righto.js
 test promises.js
 test promises-ramda.js
+test bluebird-promisell.js
 test most.js
 test coroutines-co.js
 test coroutines-bluebird.js


### PR DESCRIPTION
[The `concatFiles` function](https://github.com/plaid/async-problem/blob/master/promises-ramda.js#L22-L30) is still "big" to me.

In this PR, 

1. I'm using [`bluebird-promisell`](https://github.com/zhangchiqing/bluebird-promisell) to break the `concatFiles` function into small ones. 
2. So each small function either [play only one side effect](https://github.com/zhangchiqing/async-problem/blob/master/bluebird-promisell.js#L16-L19), or [play multiple side effects of the same type](https://github.com/zhangchiqing/async-problem/blob/master/bluebird-promisell.js#L22-L25).
3. [I like keeping the logic flat, so that the return value makes it clear what would be the resolved promise value](https://github.com/zhangchiqing/async-problem/blob/master/bluebird-promisell.js#L29-L33). 
4. The syntax reads like synchronized, but all the promises are chained. 