### PR TITLE
Add node streams example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The solutions are best read in the following order:
 
   - [__synchronous.js__](./synchronous.js)
   - [__callbacks.js__](./callbacks.js)
+  - [__node-streams.js__](./node-streams.js)
   - [__async.js__](./async.js)
   - [__righto.js__](./righto.js)
   - [__promises.js__](./promises.js)

--- a/node-streams.js
+++ b/node-streams.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const fs            = require('fs');
+
+const miss          = require('mississippi');
+const split         = require('split2');
+
+const exit0         = require('./common/exit0');
+const exit1         = require('./common/exit1');
+const join          = require('./common/join');
+const readFile      = require('./common/read-file-callback');
+
+const main = () => {
+  const path = join(process.argv[2]);
+  let results;
+
+  miss.pipe(
+    fs.createReadStream(path('index.txt')),
+    split(),
+    miss.parallel(123, (fileName, cb) => readFile(path(fileName), cb)),
+    miss.concat(data => { results = data; }),
+    err => {
+      if (err != null) exit1(err);
+      exit0(results);
+    }
+  );
+};
+
+if (process.mainModule.filename === __filename) main();

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "fluture": "6.2.x",
     "fluture-sanctuary-types": "1.2.x",
     "foreign": "1.0.x",
+    "mississippi": "3.0.x",
     "most": "1.4.x",
     "righto": "3.0.x",
     "sanctuary": "0.13.x",
-    "sanctuary-def": "0.12.x"
+    "sanctuary-def": "0.12.x",
+    "split2": "3.0.x"
   },
   "devDependencies": {
     "eslint": "3.19.x",

--- a/test
+++ b/test
@@ -50,6 +50,7 @@ test() {
 
 test synchronous.js
 test callbacks.js
+test node-streams.js
 test async.js
 test righto.js
 test promises.js


### PR DESCRIPTION
Hi! Randomly thought of this repo the other day and noticed it didn't have a node streams version. 
Since streams are the other async builtin/primitive, I thought it might be nice to have an example. 

_mississippi_ is a collection of common stream wrapper modules, for educational purposes. I included that module instead of including individual modules because it might be beneficial to point people over there for it's useful README. 